### PR TITLE
ci: download aqua.yaml

### DIFF
--- a/.github/workflows/reusable-diff.yml
+++ b/.github/workflows/reusable-diff.yml
@@ -15,6 +15,13 @@ jobs:
   diff:
     runs-on: ubuntu-latest
     steps:
+      - name: get aqua.yaml
+        run: |
+          curl -LO https://raw.githubusercontent.com/mikutas/helmfiles/refs/heads/main/aqua.yaml
+          cat aqua.yaml
+          mv aqua.yaml ../
+
+      # actions/checkout -> aquaproj/aqua-installer
       - uses: mikutas/my-aqua-installer@main
 
       - if: inputs.artifact-dl-name

--- a/apps/argo-cd/Chart.yaml
+++ b/apps/argo-cd/Chart.yaml
@@ -1,3 +1,4 @@
+# hoge
 apiVersion: v2
 name: argo-cd
 description: A Helm chart for Kubernetes


### PR DESCRIPTION
別リポジトリでワークフローを再利用するときaqua.yamlがなくてもいいように